### PR TITLE
Dockerize CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.travis.yml
+.gitignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,67 +1,10 @@
-sudo: required
-cache:
-  - apt
-
 language: generic
-matrix:
-  include:
-  - name: "Xenial kinetic"
-    dist: xenial
-    env: ROS_DISTRO=kinetic
 
-env:
-  global:
-    - ROS_CI_DESKTOP="`lsb_release -cs`"  # e.g. [precise|trusty|...]
-    - CI_SOURCE_PATH=$(pwd)
-    - ROSINSTALL_FILE=$CI_SOURCE_PATH/dependencies.rosinstall
-    - CATKIN_BLACKLIST=$CI_SOURCE_PATH/catkin.blacklist
-    - ROS_PARALLEL_JOBS='-j8 -l6'
-    # Set the python path manually to include /usr/-/python2.7/dist-packages
-    # as this is where apt-get installs python packages.
-    - PYTHONPATH=$PYTHONPATH:/usr/lib/python2.7/dist-packages:/usr/local/lib/python2.7/dist-packages
+services:
+  - docker
 
-################################################################################
-
-# Install system dependencies, namely a very barebones ROS setup.
-before_install:
-  - sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"
-  - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
-  - sudo apt-get update -qq
-  - sudo apt-get install dpkg
-  - sudo apt-get install -y --allow-unauthenticated google-mock
-  - sudo apt-get install -y --allow-unauthenticated python-catkin-pkg python-rosdep python-wstool ros-$ROS_DISTRO-ros-base python-catkin-tools
-  - source /opt/ros/$ROS_DISTRO/setup.bash
-  # Prepare rosdep to install dependencies.
-  - sudo rosdep init
-  - rosdep update
-
-# Create a catkin workspace with the package under integration.
-install:
-  - mkdir -p ~/catkin_ws/src
-  - cd ~/catkin_ws
-  - catkin init
-  # Blacklist packages specified in the blacklist-file, if it exists
-  - if [[ -f $CATKIN_BLACKLIST ]] ; then catkin config --blacklist $(<$CATKIN_BLACKLIST) ; fi
-  # Add the package under integration to the workspace using a symlink.
-  - cd ~/catkin_ws/src
-  - ln -s $CI_SOURCE_PATH .
-
-# Install all dependencies, using wstool first and rosdep second.
-# wstool looks for a ROSINSTALL_FILE defined in the environment variables.
 before_script:
-  # source dependencies: install using wstool.
-  - cd ~/catkin_ws/src
-  - wstool init
-  - if [[ -f $ROSINSTALL_FILE ]] ; then wstool merge $ROSINSTALL_FILE ; fi
-  - wstool up
-  # package depdencies: install using rosdep.
-  - cd ~/catkin_ws
-  - rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
+  - docker build --tag stim300 .
 
-# Compile
 script:
-  - source /opt/ros/$ROS_DISTRO/setup.bash
-  - cd ~/catkin_ws
-  - catkin build
-  - catkin run_tests driver_stim300 --no-deps  # will allwasy exit with 0
-  - catkin_test_results ~/catkin_ws/build/driver_stim300 # only exits with 0 if all test was good
+  - docker run stim300 catkin_test_results /catkin_ws/build/driver_stim300

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM ros:kinetic-ros-core-xenial
+WORKDIR /catkin_ws
+RUN apt-get update
+RUN apt-get install --yes python-catkin-tools
+COPY . ./src/stim300
+
+# See https://stackoverflow.com/questions/20635472/using-the-run-instruction-in-a-dockerfile-with-source-does-not-work
+RUN ["/bin/bash", "-c", "source /opt/ros/kinetic/setup.bash && \
+    catkin build && \
+    catkin run_tests driver_stim300 --no-deps"]


### PR DESCRIPTION
CI runs significantly faster this way, 4 min -> 1 min. The docker image also provides the possibility to run the stim300 ROS-package inside a docker image, even if ROS is not installed on the host-computer